### PR TITLE
Fix temp file creation for buffer types

### DIFF
--- a/dhall-mode.el
+++ b/dhall-mode.el
@@ -131,7 +131,7 @@ Should be dhall or the complete path to your dhall executable,
 (defun dhall-buffer-type ()
   "Return the type of the expression in the current buffer."
   (interactive)
-  (let ((stderr (make-temp-name "dhall-buffer-type")))
+  (let ((stderr (make-temp-file "dhall-buffer-type")))
     (call-process-region (point-min) (point-max) dhall-command nil (list nil stderr))
     (let ((type (car (split-string (with-temp-buffer
                                      (insert-file-contents stderr)
@@ -139,6 +139,7 @@ Should be dhall or the complete path to your dhall executable,
                                    "[]+"
                                    t
                                    split-string-default-separators))))
+      (delete-file stderr)
       (unless (string-match-p "↳" type)
         (ansi-color-apply (replace-regexp-in-string "\n" " " type))))))
 


### PR DESCRIPTION
The existing code was erroneously creating files in the current working directory, sorry. This fixes the issue in order to use the temp directory instead, and also to unlink the temp file after use.