### PR TITLE
Provide basic dhall-repl integration

### DIFF
--- a/dhall-mode.el
+++ b/dhall-mode.el
@@ -42,6 +42,15 @@
 ;;; Code:
 
 (require 'ansi-color)
+(require 'dhall-repl)
+
+(defvar dhall-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c C-b") 'dhall-repl-show)
+    (define-key map (kbd "C-c C-f") 'dhall-format)
+    (define-key map (kbd "C-c C-t") 'dhall-buffer-type)
+    map)
+"Keymap for using `dhall-mode'.")
 
 (defgroup dhall nil
   "Major mode for editing dhall files"
@@ -272,6 +281,7 @@ STRING-TYPE type of string based off of Emacs syntax table types"
   "Dhall"
   "Major mode for editing Dhall files."
   :group 'dhall
+  :keymap dhall-mode-map
   :syntax-table dhall-mode-syntax-table
   (when dhall-use-header-line
     (setq header-line-format

--- a/dhall-repl.el
+++ b/dhall-repl.el
@@ -2,6 +2,9 @@
 
 ;; Copyright (C) 2018 Patrick D. Elliott
 
+;; Author: Patrick D. Elliott <patrick.d.elliott@gmail.com>
+;; Keywords: Languages
+
 ;; This file is not part of GNU Emacs.
 
 ;; This file is free software; you can redistribute it and/or modify

--- a/dhall-repl.el
+++ b/dhall-repl.el
@@ -1,0 +1,54 @@
+;;; dhall-repl.el --- Dhall repl -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2018 Patrick D. Elliott
+
+;; This file is not part of GNU Emacs.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; A simple repl for dhall based on comint
+
+;;; Code:
+
+(defvar dhall-prompt-regexp "⊢ ")
+
+(require 'comint)
+
+(defcustom dhall-repl-executable "dhall-repl"
+  "Location of dhall-repl command."
+:type 'string)
+
+(define-derived-mode dhall-repl-mode comint-mode "Dhall-REPL"
+  "Interactive prompt for Dhall."
+  (setq-local comint-prompt-regexp dhall-prompt-regexp)
+(setq-local comint-prompt-read-only t))
+
+(defun dhall-repl-show ()
+  "Load the Dhall-REPL."
+  (interactive)
+  (pop-to-buffer-same-window
+   (get-buffer-create "*Dhall-REPL*"))
+  (unless (comint-check-proc (current-buffer))
+    (dhall--make-repl-in-buffer (current-buffer))
+(dhall-repl-mode)))
+
+(defun dhall--make-repl-in-buffer (buffer)
+  "Make Dhall Repl in BUFFER."
+  (apply
+   'make-comint-in-buffer `("Dhall-REPL" ,buffer ,dhall-repl-executable nil)))
+
+(provide 'dhall-repl)
+;;; dhall-repl.el ends here


### PR DESCRIPTION
Provides `dhall-repl-show` - an interactive function for opening the dhall repl