### PR TITLE
Make change timeout configurable, don't run typecheck if not needed

### DIFF
--- a/dhall-mode.el
+++ b/dhall-mode.el
@@ -132,7 +132,7 @@ If specified, this should be the complete path to your dhall-format executable,
   :safe t)
 
 (defcustom dhall-type-check-inactivity-timeout 1
-  "How long to wait in seconds between inactivity in the buffer before evaluating the buffer type. You can try increasing this if type checking is slowing things down. You can also disable type-checking entirely by setting dhall-use-header-line to nil."
+  "How long to wait in seconds between inactivity in the buffer before evaluating the buffer type.  You can try increasing this if type checking is slowing things down.  You can also disable type-checking entirely by setting dhall-use-header-line to nil."
   :type 'number
   :group 'dhall
   :safe 'numberp)

--- a/dhall-mode.el
+++ b/dhall-mode.el
@@ -131,6 +131,12 @@ If specified, this should be the complete path to your dhall-format executable,
   :group 'dhall
   :safe t)
 
+(defcustom dhall-type-check-inactivity-timeout 1
+  "How long to wait in seconds between inactivity in the buffer before evaluating the buffer type. You can try increasing this if type checking is slowing things down. You can also disable type-checking entirely by setting dhall-use-header-line to nil."
+  :type 'number
+  :group 'dhall
+  :safe 'numberp)
+
 (defun dhall-buffer-type ()
   "Return the type of the expression in the current buffer."
   (interactive)
@@ -262,9 +268,10 @@ STRING-TYPE type of string based off of Emacs syntax table types"
 
 (defun dhall-after-change (&optional _beg _end _length)
   "Called after any change in the buffer."
-  (when dhall-buffer-type-compute-timer
+  (when dhall-use-header-line
+    (when dhall-buffer-type-compute-timer
     (cancel-timer dhall-buffer-type-compute-timer))
-  (setq dhall-buffer-type-compute-timer (run-at-time 1 nil 'dhall-buffer-type-compute)))
+  (setq dhall-buffer-type-compute-timer (run-at-time dhall-type-check-inactivity-timeout nil 'dhall-buffer-type-compute))))
 
 ;; The main mode functions
 ;;;###autoload


### PR DESCRIPTION
This is for #17. It looks like there was already some intent expressed
in the code to not run the after change hook if
`dhall-use-header-line` was disabled, but it wasn't enacted when the
hook showed up. At first I thought I might just not register the hook
if `dhall-use-header-line` was disabled, but that would create
confusing behavior if the user live-configured their emacs to enable
that. So the hook will always fire but it will be a no-op if the type
won't be used.

Also for good measure I moved the timeout into an option so folks who
are having performance problems but don't want to completely abandon
buffer type can make a tradeoff in feedback cycle time for
responsiveness.

The motivation behind this is that on moderately large files, running
the type check every second makes any modification to the buffer
completely lock up. I'm happy to turn off the buffer type feature keep
the rest of the functionality like auto-reformatting and syntax
highlighting.