### PR TITLE
Add option for ASCII formatting

### DIFF
--- a/dhall-mode.el
+++ b/dhall-mode.el
@@ -140,7 +140,7 @@ If specified, this should be the complete path to your dhall-format executable,
   :safe 'booleanp)
 
 (defcustom dhall-format-arguments nil
-  "Provide a list of arguments for the formatter e.g. --ascii."
+  "Provide a list of arguments for the formatter e.g. '(\"--ascii\")."
   :type 'list
   :group 'dhall
   :safe 'listp)

--- a/dhall-mode.el
+++ b/dhall-mode.el
@@ -139,11 +139,11 @@ If specified, this should be the complete path to your dhall-format executable,
   :group 'dhall
   :safe 'booleanp)
 
-(defcustom dhall-format-with-ascii nil
-  "If non-nil, the Dhall buffers will be formatted using ASCII-only."
-  :type 'boolean
+(defcustom dhall-format-arguments ()
+  "Provide a list of arguments for the formatter e.g. --ascii."
+  :type 'list
   :group 'dhall
-  :safe 'booleanp)
+  :safe 'listp)
 
 (defcustom dhall-type-check-inactivity-timeout 1
   "Wait for this period of inactivity before refreshing the buffer type.
@@ -183,8 +183,7 @@ down.  You can also disable type-checking entirely by setting
 
 (reformatter-define dhall-format
   :program (or dhall-format-command dhall-command)
-  :args (append (unless dhall-format-command '("format"))
-                (when dhall-format-with-ascii '("--ascii")))
+  :args (append (unless dhall-format-command '("format")) dhall-format-arguments)
   :group 'dhall
   :lighter " DhFmt")
 

--- a/dhall-mode.el
+++ b/dhall-mode.el
@@ -139,7 +139,7 @@ If specified, this should be the complete path to your dhall-format executable,
   :group 'dhall
   :safe 'booleanp)
 
-(defcustom dhall-format-arguments ()
+(defcustom dhall-format-arguments nil
   "Provide a list of arguments for the formatter e.g. --ascii."
   :type 'list
   :group 'dhall

--- a/dhall-mode.el
+++ b/dhall-mode.el
@@ -139,6 +139,12 @@ If specified, this should be the complete path to your dhall-format executable,
   :group 'dhall
   :safe 'booleanp)
 
+(defcustom dhall-format-with-ascii nil
+  "If non-nil, the Dhall buffers will be formatted using ASCII-only."
+  :type 'boolean
+  :group 'dhall
+  :safe 'booleanp)
+
 (defcustom dhall-type-check-inactivity-timeout 1
   "Wait for this period of inactivity before refreshing the buffer type.
 You can try increasing this if type checking is slowing things
@@ -177,7 +183,8 @@ down.  You can also disable type-checking entirely by setting
 
 (reformatter-define dhall-format
   :program (or dhall-format-command dhall-command)
-  :args (unless dhall-format-command '("format"))
+  :args (let ((cmd (if dhall-format-with-ascii '("--ascii") '())))
+          (if dhall-format-command cmd (cons "format" cmd)))
   :group 'dhall
   :lighter " DhFmt")
 

--- a/dhall-mode.el
+++ b/dhall-mode.el
@@ -183,8 +183,8 @@ down.  You can also disable type-checking entirely by setting
 
 (reformatter-define dhall-format
   :program (or dhall-format-command dhall-command)
-  :args (let ((cmd (if dhall-format-with-ascii '("--ascii") '())))
-          (if dhall-format-command cmd (cons "format" cmd)))
+  :args (append (unless dhall-format-command '("format"))
+                (when dhall-format-with-ascii '("--ascii")))
   :group 'dhall
   :lighter " DhFmt")
 


### PR DESCRIPTION
First pass at https://github.com/psibi/dhall-mode/issues/25. Adds the `--ascii` flag to the format command if  `dhall-format-with-ascii` is set.